### PR TITLE
Update flutter_rust_bridge to v1.82.0 and add parseErrorData

### DIFF
--- a/packages/metadata_god/example/android/build.gradle
+++ b/packages/metadata_god/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/metadata_god/lib/src/bridge_generated.dart
+++ b/packages/metadata_god/lib/src/bridge_generated.dart
@@ -83,18 +83,15 @@ class MetadataGodImpl implements MetadataGod {
       callFfi: (port_) => _platform.inner.wire_read_metadata(port_, arg0),
       parseSuccessData: _wire2api_metadata,
       constMeta: kReadMetadataConstMeta,
-      argValues: [
-        file
-      ],
+      argValues: [file],
       hint: hint,
+      parseErrorData: parseReturnedError,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kReadMetadataConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "read_metadata",
-        argNames: [
-          "file"
-        ],
+        argNames: ["file"],
       );
 
   Future<void> writeMetadata({required String file, required Metadata metadata, dynamic hint}) {
@@ -104,20 +101,15 @@ class MetadataGodImpl implements MetadataGod {
       callFfi: (port_) => _platform.inner.wire_write_metadata(port_, arg0, arg1),
       parseSuccessData: _wire2api_unit,
       constMeta: kWriteMetadataConstMeta,
-      argValues: [
-        file,
-        metadata
-      ],
+      argValues: [file, metadata],
       hint: hint,
+      parseErrorData: parseReturnedError,
     ));
   }
 
   FlutterRustBridgeTaskConstMeta get kWriteMetadataConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "write_metadata",
-        argNames: [
-          "file",
-          "metadata"
-        ],
+        argNames: ["file", "metadata"],
       );
 
   void dispose() {
@@ -175,6 +167,11 @@ class MetadataGodImpl implements MetadataGod {
       picture: _wire2api_opt_box_autoadd_picture(arr[11]),
       fileSize: _wire2api_opt_box_autoadd_u64(arr[12]),
     );
+  }
+
+  String parseReturnedError(dynamic errorData) {
+    // Convert the error data to a string representation.
+    return errorData.toString();
   }
 
   String? _wire2api_opt_String(dynamic raw) {

--- a/packages/metadata_god/pubspec.yaml
+++ b/packages/metadata_god/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^2.0.2
-  flutter_rust_bridge: ^1.80.1
+  flutter_rust_bridge: ^1.82.1
   uuid: ^3.0.7
   meta: ^1.8.0
 


### PR DESCRIPTION
This PR updates the library to support `flutter_rust_bridge` version 1.82.0. The main changes include:
- Updated the `flutter_rust_bridge` version in `pubspec.yaml`.
- Added the required `parseErrorData` parameter to handle error data returned by the underlying Rust function.

These changes ensure compatibility with the latest version of `flutter_rust_bridge` and address the compilation errors faced by users updating to this version.
